### PR TITLE
Update to v1.34.11

### DIFF
--- a/omnisharp-mono.rb
+++ b/omnisharp-mono.rb
@@ -1,9 +1,9 @@
 class OmnisharpMono < Formula
   desc "Cross platform .NET development in the editor of your choice"
   homepage "http://www.omnisharp.net/"
-  url "https://github.com/OmniSharp/omnisharp-roslyn/releases/download/v1.19.0/omnisharp-mono.tar.gz"
-  version "1.19.0"
-  sha256 "80a9ff14f5939c1cf32bc6264d4c813ee0a6c23027a3301338f94858d6b79c31"
+  url "https://github.com/OmniSharp/omnisharp-roslyn/releases/download/v1.34.11/omnisharp-mono.tar.gz"
+  version "1.34.11"
+  sha256 "c3f407aea71524355f5001e5e5572f834e6a746abe3a1852bd40f9136596a548"
   conflicts_with "omnisharp"
 
   depends_on "mono" => :recommended

--- a/omnisharp-mono.rb
+++ b/omnisharp-mono.rb
@@ -12,7 +12,7 @@ class OmnisharpMono < Formula
     libexec.install Dir["*"]
 
     # To match non-mono install, create an `omnisharp' shell script.
-    (bin/"omnisharp").write <<-EOS.undent
+    (bin/"omnisharp").write <<-EOS
       #!/usr/bin/env sh
       mono /usr/local/opt/omnisharp-mono/libexec/OmniSharp.exe $@
     EOS

--- a/omnisharp.rb
+++ b/omnisharp.rb
@@ -1,9 +1,9 @@
 class Omnisharp < Formula
   desc "Cross platform .NET development in the editor of your choice"
   homepage "http://www.omnisharp.net/"
-  url "https://github.com/OmniSharp/omnisharp-roslyn/releases/download/v1.19.0/omnisharp-osx-x64-netcoreapp1.1.tar.gz"
-  version "1.19.0"
-  sha256 "6366dedb8fed547bb1cad40a2051c642287069793a22d7a3a3ba8cdbc0f932b4"
+  url "https://github.com/OmniSharp/omnisharp-roslyn/releases/download/v1.34.11/omnisharp-osx.tar.gz"
+  version "1.34.11"
+  sha256 "f9d2cf59fa1e690412cf89aefb8e4989a264855487c68ab0fea3adac165ada9d"
   conflicts_with "omnisharp-mono"
 
   depends_on "mono" => :recommended


### PR DESCRIPTION
This updates omnisharp roslyn to the latest 1.34.11 version, which should reinstate LSP capability.

Per [OmniSharp/omnisharp-roslyn/pull/#915 ](https://github.com/OmniSharp/omnisharp-roslyn/pull/915) ("This PR moves OmniSharp to target .NET Framework 4.6 exclusively and removes all of the netcoreapp1.1 builds."), bundled asset names have changed.

This pull request seeks to update both the OmniSharp version and the associated assets for this formula.

Additionally, undent method-call was removed due to the deprecation of this method. Currently, the "undented" script will remain as-is (meaning that the script will be written _with_ indentation, but this should be fine!)