### PR TITLE
Use updated libexec path

### DIFF
--- a/omnisharp-mono.rb
+++ b/omnisharp-mono.rb
@@ -14,7 +14,7 @@ class OmnisharpMono < Formula
     # To match non-mono install, create an `omnisharp' shell script.
     (bin/"omnisharp").write <<~EOS
       #!/usr/bin/env sh
-      mono /usr/local/opt/omnisharp-mono/libexec/OmniSharp.exe $@
+      mono "#{libexec}/OmniSharp.exe" $@
     EOS
   end
 


### PR DESCRIPTION
On later versions of macOS, /usr is no longer normally writable. Homebrew instead installs content into /opt/homebrew/Cellar.

On my system, OmniSharp.exe was installed into

    /opt/homebrew/Cellar/omnisharp-mono/1.35.3/libexec

This patch uses the `libexec` symbol described at [1] to make this formula platform-agnostic.

[1]: https://docs.brew.sh/Formula-Cookbook#variables-for-directory-locations

---

Please note that this is the first formula I've ever edited – and probably one of fewer than ten that I've actually bothered to look inside. **I do not know how to test this change!** I have a passing grasp of Ruby syntax, so please review this patch with due scrutiny before merging.